### PR TITLE
Use forward slashes in paths instead of backslashes

### DIFF
--- a/templates/header.erb
+++ b/templates/header.erb
@@ -13,9 +13,9 @@
 <%- if @nxlog_root -%>
 define ROOT <%= @nxlog_root %>
 
-Moduledir %ROOT%\modules
-CacheDir %ROOT%\data
-Pidfile %ROOT%\data\nxlog.pid
-SpoolDir %ROOT%\data
-LogFile %ROOT%\data\nxlog.log
+Moduledir %ROOT%/modules
+CacheDir %ROOT%/data
+Pidfile %ROOT%/data/nxlog.pid
+SpoolDir %ROOT%/data
+LogFile %ROOT%/data/nxlog.log
 <%- end %>


### PR DESCRIPTION
This solves an issue on Linux where I run into this issue (the directory /opt/nxlog/data exists):

Starting nxlog daemon...
Oct 17 16:46:48 ... nxlog[28950]: Couldn't change to SpoolDir '/opt/nxlog\data';No such file or directory
