### PR TITLE
Add input_options

### DIFF
--- a/manifests/config/input.pp
+++ b/manifests/config/input.pp
@@ -17,6 +17,7 @@ define nxlog::config::input (
   $input_execs     = $::nxlog::input_execs,
   $input_file_path = $::nxlog::input_file_path,
   $input_module    = $::nxlog::input_module,
+  $input_options   = $::nxlog::input_options,
   $input_type      = $::nxlog::input_type,
   $order_input     = $::nxlog::order_input,) {
   concat::fragment { "input_${name}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class nxlog (
   $input_execs                 = $::nxlog::params::input_execs,
   $input_file_path             = $::nxlog::params::input_file_path,
   $input_module                = $::nxlog::params::input_module,
+  $input_options               = $::nxlog::params::input_options,
   $input_type                  = $::nxlog::params::input_type,
   $nxlog_root                  = $::nxlog::params::nxlog_root,
   $order_extension             = $::nxlog::params::order_extension,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class nxlog::params {
   $ext_options                 = undef
   $input_execs                 = []
   $input_module                = undef
+  $input_options               = undef
   $input_file_path             = undef
   $input_type                  = undef
   $nxlog_root                  = undef

--- a/spec/defines/config_input_spec.rb
+++ b/spec/defines/config_input_spec.rb
@@ -52,7 +52,7 @@ describe 'nxlog::config::input', type: :define do
         it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{<Input logfile>}) }
         it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sModule\s+im_file}) }
         it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sFile\s+'C:/logfile\.log'}) }
-        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sInputType\s+'multiline'}) }
+        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sInputType\s+multiline}) }
         it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{</Input>}) }
       end
     end

--- a/templates/input.erb
+++ b/templates/input.erb
@@ -10,7 +10,7 @@
   File        <%= "'#{@input_file_path}'" %>
   <%- end %>
   <%- if @input_type -%>
-  InputType   <%= "'#{@input_type}'" %>
+  InputType   <%= @input_type %>
   <%- end %>
   <% [*@input_options].each do |input_option| -%><%="#{input_option}" %>
 <% end %></Input>

--- a/templates/input.erb
+++ b/templates/input.erb
@@ -12,4 +12,5 @@
   <%- if @input_type -%>
   InputType   <%= "'#{@input_type}'" %>
   <%- end %>
-</Input>
+  <% [*@input_options].each do |input_option| -%><%="#{input_option}" %>
+<% end %></Input>


### PR DESCRIPTION
Please see changes in the PR to add `input_options` parameter in order to specify additional directives for the input. For example, we need to be able to set the parameter `input_options   => [ 'SavePos     TRUE', ],` in an `nxlog::config::input` defined type.

Also, I encountered nxlog errors that caused the service not to start due to the single quotes included with the value of `InputType`. For example, the InputType for the Input we were using had to be `InputType   LineBased` instead of `InputType   'LineBased'`.

What do you think of these changes?


I tried fixing the unrelated failures `LoadError: cannot load such file -- win32ole`, but no luck. Any idea?

Thanks,