### PR TITLE
Added the parameter 'input_recursive' for type 'nxlog::config::input'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,17 +117,21 @@ name.
 `nxlog::config::input` - builds an Input section using the specified name.
 
 * `input_execs`  - an array of Exec statements to include (Optional)
-*	`input_file_path` - defines the path to use if reading from a local file
+* `input_file_path` - defines the path to use if reading from a local file
 * `input_module` - the name of the input module to use
 * `input_type` - the name of the registered input reader function to use
+* `input_recursive` - If set to True, this boolean directive specifies 
+  that a file path set in the parameter `input_file_path` should be 
+  searched recursively under sub-directories. Use it if you file path 
+  contains a wildcard
 
 `nxlog::config::output` - builds an Output section using the specified name.
 
 * `output_address`   - the address of the remote host to send data to
 * `output_execs`  - an array of Exec statements to include (Optional)
-*	`output_file_path` - defines the path to use if writing to a local file
+* `output_file_path` - defines the path to use if writing to a local file
 * `output_module`    - the name of the output module to use
-*	`output_port`      - the port on the remote host to send data to
+* `output_port`      - the port on the remote host to send data to
 
 `nxlog::config::processor` - builds a Processor section using the specified name.
 

--- a/manifests/config/input.pp
+++ b/manifests/config/input.pp
@@ -18,6 +18,7 @@ define nxlog::config::input (
   $input_file_path = $::nxlog::input_file_path,
   $input_module    = $::nxlog::input_module,
   $input_type      = $::nxlog::input_type,
+  $input_recursive = $::nxlog::input_recursive,
   $order_input     = $::nxlog::order_input,) {
   concat::fragment { "input_${name}":
     target  => "${conf_dir}/${conf_file}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class nxlog (
   $input_file_path             = $::nxlog::params::input_file_path,
   $input_module                = $::nxlog::params::input_module,
   $input_type                  = $::nxlog::params::input_type,
+  $input_recursive             = $::nxlog::params::input_recursive,
   $nxlog_root                  = $::nxlog::params::nxlog_root,
   $order_extension             = $::nxlog::params::order_extension,
   $order_header                = $::nxlog::params::order_header,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class nxlog::params {
   $input_module                = undef
   $input_file_path             = undef
   $input_type                  = undef
+  $input_recursive             = undef
   $nxlog_root                  = undef
   $output_address              = undef
   $output_execs                = []

--- a/templates/input.erb
+++ b/templates/input.erb
@@ -12,4 +12,7 @@
   <%- if @input_type -%>
   InputType   <%= "'#{@input_type}'" %>
   <%- end %>
+  <%- if @input_recursive -%>
+  Recursive   <%= @input_recursive %>
+  <%- end %>
 </Input>


### PR DESCRIPTION
I'm going to use the module for an enterprise project. The latest version of this module looks good, but it doesn't have the parameter 'Recursive' in the Input block. The NXLog can work with sub-folder in file path, if the file path contains a wildcard. I'm sure it would be great to have this parameter.