### PR TITLE
Fix line endings for Linux

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,9 +2,11 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "genebean/centos-7-puppet-latest"
+  config.vm.box = "genebean/centos-7-rvm-multi"
   config.vm.synced_folder ".", "/vagrant"
 
-  config.vm.provision "shell", inline: "yum -y install multitail pdk"
-  config.vm.provision "shell", inline: "su - vagrant -c 'export PUP_MOD=genebean-nxlog; rsync -rv --delete /vagrant/ /home/vagrant/$PUP_MOD'"
+  config.vm.provision "shell", inline: "yum -y install multitail vim nano git"
+  config.vm.provision "shell", inline: "su - vagrant -c 'rvm install ruby-2.5.7; rvm use ruby 2.5.7 --default'"
+  config.vm.provision "shell", inline: "gem install bundler"
+  config.vm.provision "shell", inline: "su - vagrant -c 'export PUP_MOD=genebean-nxlog; rsync -rv --delete /vagrant/ /home/vagrant/$PUP_MOD --exclude bundle; cd /home/vagrant/$PUP_MOD; bundle install --jobs=3 --retry=3; bundle exec rake spec_prep'"
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,16 +8,31 @@ class nxlog::config (
     ensure_newline => true,
   }
 
+  $header_template = template('nxlog/header.erb')
+  $footer_template = "\n"
+
+  $header_converted = $facts['kernel'] ? {
+    'Linux'   => dos2unix($header_template),
+    'Windows' => unix2dos($header_template),
+    default   => dos2unix($header_template),
+  }
+
+  $footer_converted = $facts['kernel'] ? {
+    'Linux'   => dos2unix($footer_template),
+    'Windows' => unix2dos($footer_template),
+    default   => dos2unix($footer_template),
+  }
+
   concat::fragment { 'conf_header':
     target  => "${conf_dir}/${conf_file}",
-    content => unix2dos(template('nxlog/header.erb')),
+    content => $header_converted,
     order   => '01',
   }
 
   # Ensure there is a blank line at the end of the file
   concat::fragment { 'conf_footer':
     target  => "${conf_dir}/${conf_file}",
-    content => unix2dos("\n"),
+    content => $footer_converted,
     order   => '99',
   }
 

--- a/manifests/config/extension.pp
+++ b/manifests/config/extension.pp
@@ -13,9 +13,18 @@ define nxlog::config::extension (
   $ext_module      = $nxlog::ext_module,
   $ext_options     = $nxlog::ext_options,
   $order_extension = $nxlog::order_extension,) {
+
+  $extension_template = template('nxlog/extension.erb')
+
+  $extension_converted = $facts['kernel'] ? {
+    'Linux'   => dos2unix($extension_template),
+    'Windows' => unix2dos($extension_template),
+    default   => dos2unix($extension_template),
+  }
+
   concat::fragment { "extension_${name}":
     target  => "${conf_dir}/${conf_file}",
     order   => $order_extension,
-    content => unix2dos(template('nxlog/extension.erb')),
+    content => $extension_converted,
   }
 }

--- a/manifests/config/input.pp
+++ b/manifests/config/input.pp
@@ -20,9 +20,18 @@ define nxlog::config::input (
   $input_options   = $nxlog::input_options,
   $input_type      = $nxlog::input_type,
   $order_input     = $nxlog::order_input,) {
+
+  $input_template = template('nxlog/input.erb')
+
+  $input_converted = $facts['kernel'] ? {
+    'Linux'   => dos2unix($input_template),
+    'Windows' => unix2dos($input_template),
+    default   => dos2unix($input_template),
+  }
+
   concat::fragment { "input_${name}":
     target  => "${conf_dir}/${conf_file}",
     order   => $order_input,
-    content => unix2dos(template('nxlog/input.erb')),
+    content => $input_converted,
   }
 }

--- a/manifests/config/output.pp
+++ b/manifests/config/output.pp
@@ -25,9 +25,17 @@ define nxlog::config::output (
   $output_options   = $nxlog::output_options,
   $output_port      = $nxlog::output_port,) {
 
+  $output_template = template('nxlog/output.erb')
+
+  $output_converted = $facts['kernel'] ? {
+    'Linux'   => dos2unix($output_template),
+    'Windows' => unix2dos($output_template),
+    default   => dos2unix($output_template),
+  }
+
   concat::fragment { "output_${name}":
     target  => "${conf_dir}/${conf_file}",
     order   => $order_output,
-    content => unix2dos(template('nxlog/output.erb')),
+    content => $output_converted,
   }
 }

--- a/manifests/config/processor.pp
+++ b/manifests/config/processor.pp
@@ -40,9 +40,15 @@ define nxlog::config::processor (
     fail('processor_csv_output_fields must be an array.')
   }
 
+  $processor_converted = $facts['kernel'] ? {
+    'Linux'   => dos2unix(template($processor_template)),
+    'Windows' => unix2dos(template($processor_template)),
+    default   => dos2unix(template($processor_template)),
+  }
+
   concat::fragment { "processor_${name}":
     target  => "${conf_dir}/${conf_file}",
     order   => $order_processor,
-    content => unix2dos(template($processor_template)),
+    content => $processor_converted,
   }
 }

--- a/manifests/config/route.pp
+++ b/manifests/config/route.pp
@@ -17,9 +17,18 @@ define nxlog::config::route (
   $order_route       = $nxlog::order_route,
   $route_destination = $nxlog::route_destination,
   $route_source      = $nxlog::route_source,) {
+
+  $route_template = template('nxlog/route.erb')
+
+  $route_converted = $facts['kernel'] ? {
+    'Linux'   => dos2unix($route_template),
+    'Windows' => unix2dos($route_template),
+    default   => dos2unix($route_template),
+  }
+
   concat::fragment { "route_${name}":
     target  => "${conf_dir}/${conf_file}",
     order   => $order_route,
-    content => unix2dos(template('nxlog/route.erb')),
+    content => $route_converted,
   }
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -30,12 +30,51 @@ describe 'nxlog::config' do
       )
     }
 
-    it { is_expected.to contain_concat__fragment('conf_header').with_content(%r{define ROOT C:/nxlog}) }
+    it { is_expected.to contain_concat__fragment('conf_header').with_content(%r{define ROOT C:/nxlog\r\n}) }
 
     it {
       is_expected.to contain_concat__fragment('conf_footer').with(
         'target'  => 'C:/nxlog/conf/nxlog.conf',
         'content' => "\r\n",
+        'order'   => '99',
+      )
+    }
+  end
+
+  context 'On Linux' do
+    let :facts do
+      {
+        kernel: 'Linux',
+        osfamily: 'RedHat',
+        concat_basedir: File.join(Puppet[:vardir], 'concat'),
+      }
+    end
+
+    let :pre_condition do
+      "class {'nxlog':
+        conf_dir   => '/etc',
+        conf_file  => 'nxlog.conf',
+        nxlog_root => '/etc',
+      }"
+    end
+
+    it 'uses concat to build the config file' do
+      is_expected.to contain_concat('/etc/nxlog.conf')
+    end
+
+    it {
+      is_expected.to contain_concat__fragment('conf_header').with(
+        'target'  => '/etc/nxlog.conf',
+        'order'   => '01',
+      )
+    }
+
+    it { is_expected.to contain_concat__fragment('conf_header').with_content(%r{define ROOT /etc\n}) }
+
+    it {
+      is_expected.to contain_concat__fragment('conf_footer').with(
+        'target'  => '/etc/nxlog.conf',
+        'content' => "\n",
         'order'   => '99',
       )
     }

--- a/spec/defines/config_extension_spec.rb
+++ b/spec/defines/config_extension_spec.rb
@@ -24,9 +24,9 @@ describe 'nxlog::config::extension', type: :define do
       let(:title) { 'json' }
 
       describe 'builds an Extension section for the config file which' do
-        it { is_expected.to contain_concat__fragment('extension_json').with_content(%r{<Extension json>}) }
-        it { is_expected.to contain_concat__fragment('extension_json').with_content(%r{\s\sModule\s+xm_json}) }
-        it { is_expected.to contain_concat__fragment('extension_json').with_content(%r{</Extension>}) }
+        it { is_expected.to contain_concat__fragment('extension_json').with_content(%r{<Extension json>\r\n}) }
+        it { is_expected.to contain_concat__fragment('extension_json').with_content(%r{\s\sModule\s+xm_json\r\n}) }
+        it { is_expected.to contain_concat__fragment('extension_json').with_content(%r{</Extension>\r\n}) }
       end
     end
 
@@ -48,12 +48,69 @@ describe 'nxlog::config::extension', type: :define do
       let(:title) { 'csv' }
 
       describe 'builds an Extension section for the config file which' do
-        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{<Extension csv>}) }
-        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sModule\s+xm_csv}) }
-        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sFields\s\$id,\s\$name,\s\$number}) }
-        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sFieldTypes\sinteger,\sstring,\sinteger}) }
-        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sDelimiter\s,}) }
-        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{</Extension>}) }
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{<Extension csv>\r\n}) }
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sModule\s+xm_csv\r\n}) }
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sFields\s\$id,\s\$name,\s\$number\r\n}) }
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sFieldTypes\sinteger,\sstring,\sinteger\r\n}) }
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sDelimiter\s,\r\n}) }
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{</Extension>\r\n}) }
+      end
+    end
+  end
+
+  context 'On Linux using' do
+    let :facts do
+      {
+        kernel: 'Linux',
+        osfamily: 'RedHat',
+        operatingsystem: 'RedHat',
+        concat_basedir: File.join(Puppet[:vardir], 'concat'),
+      }
+    end
+
+    context 'using xm_json' do
+      let :pre_condition do
+        "class {'nxlog':
+          conf_dir   => '/etc',
+          conf_file  => 'nxlog.conf',
+          ext_module => 'xm_json',
+          nxlog_root => '/etc'
+        }"
+      end
+
+      let(:title) { 'json' }
+
+      describe 'builds an Extension section for the config file which' do
+        it { is_expected.to contain_concat__fragment('extension_json').with_content(%r{<Extension json>\n}) }
+        it { is_expected.to contain_concat__fragment('extension_json').with_content(%r{\s\sModule\s+xm_json\n}) }
+        it { is_expected.to contain_concat__fragment('extension_json').with_content(%r{</Extension>\n}) }
+      end
+    end
+
+    context 'using xm_csv' do
+      let :pre_condition do
+        "class {'nxlog':
+          conf_dir    => '/etc',
+          conf_file   => 'nxlog.conf',
+          ext_module  => 'xm_csv',
+          ext_options => [
+            'Fields	$id, $name, $number',
+            'FieldTypes integer, string, integer',
+            'Delimiter	,',
+          ],
+          nxlog_root  => '/etc'
+        }"
+      end
+
+      let(:title) { 'csv' }
+
+      describe 'builds an Extension section for the config file which' do
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{<Extension csv>\n}) }
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sModule\s+xm_csv\n}) }
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sFields\s\$id,\s\$name,\s\$number\n}) }
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sFieldTypes\sinteger,\sstring,\sinteger\n}) }
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{\s\sDelimiter\s,\n}) }
+        it { is_expected.to contain_concat__fragment('extension_csv').with_content(%r{</Extension>\n}) }
       end
     end
   end

--- a/spec/defines/config_input_spec.rb
+++ b/spec/defines/config_input_spec.rb
@@ -27,11 +27,11 @@ describe 'nxlog::config::input', type: :define do
     let(:title) { 'eventlog_json' }
 
     describe 'builds an Input section for the config file which' do
-      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{<Input eventlog_json>}) }
-      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{\s\sModule\s+im_msvistalog}) }
-      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{\s\sExec\s+delete\(\$Keywords\);}) }
-      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{\s\sExec\s+\$raw_event\s\=\sto_json\(\);}) }
-      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{</Input>}) }
+      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{<Input eventlog_json>\r\n}) }
+      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{\s\sModule\s+im_msvistalog\r\n}) }
+      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{\s\sExec\s+delete\(\$Keywords\);\r\n}) }
+      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{\s\sExec\s+\$raw_event\s\=\sto_json\(\);\r\n}) }
+      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{</Input>\r\n}) }
     end
 
     describe 'inputting from a local file' do
@@ -49,11 +49,68 @@ describe 'nxlog::config::input', type: :define do
       let(:title) { 'logfile' }
 
       describe 'builds an Input section for the config file which' do
-        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{<Input logfile>}) }
-        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sModule\s+im_file}) }
-        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sFile\s+'C:/logfile\.log'}) }
-        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sInputType\s+multiline}) }
-        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{</Input>}) }
+        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{<Input logfile>\r\n}) }
+        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sModule\s+im_file\r\n}) }
+        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sFile\s+'C:/logfile\.log'\r\n}) }
+        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sInputType\s+multiline\r\n}) }
+        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{</Input>\r\n}) }
+      end
+    end
+  end
+
+  context 'On Linux' do
+    let :facts do
+      {
+        kernel: 'Linux',
+        osfamily: 'RedHat',
+        operatingsystem: 'Redhat',
+        concat_basedir: File.join(Puppet[:vardir], 'concat'),
+      }
+    end
+
+    let :pre_condition do
+      "class {'nxlog':
+        conf_dir     => '/etc',
+        conf_file    => 'nxlog.conf',
+        input_execs  => [
+          'delete($Keywords)',
+          '$raw_event = to_json()',
+        ],
+        input_module => 'im_msvistalog',
+        nxlog_root   => '/etc'
+      }"
+    end
+
+    let(:title) { 'eventlog_json' }
+
+    describe 'builds an Input section for the config file which' do
+      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{<Input eventlog_json>\n}) }
+      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{\s\sModule\s+im_msvistalog\n}) }
+      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{\s\sExec\s+delete\(\$Keywords\);\n}) }
+      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{\s\sExec\s+\$raw_event\s\=\sto_json\(\);\n}) }
+      it { is_expected.to contain_concat__fragment('input_eventlog_json').with_content(%r{</Input>\n}) }
+    end
+
+    describe 'inputting from a local file' do
+      let :pre_condition do
+        "class {'nxlog':
+          conf_dir        => '/etc',
+          conf_file       => 'nxlog.conf',
+          nxlog_root      => '/etc',
+          input_file_path => '/etc/logfile.log',
+          input_module    => 'im_file',
+          input_type      => 'multiline',
+        }"
+      end
+
+      let(:title) { 'logfile' }
+
+      describe 'builds an Input section for the config file which' do
+        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{<Input logfile>\n}) }
+        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sModule\s+im_file\n}) }
+        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sFile\s+'/etc/logfile\.log'\n}) }
+        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{\s\sInputType\s+multiline\n}) }
+        it { is_expected.to contain_concat__fragment('input_logfile').with_content(%r{</Input>\n}) }
       end
     end
   end

--- a/spec/defines/config_output_spec.rb
+++ b/spec/defines/config_output_spec.rb
@@ -27,12 +27,12 @@ describe 'nxlog::config::output', type: :define do
       let(:title) { 'logserver' }
 
       describe 'builds an Output section for the config file which' do
-        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{<Output logserver>}) }
-        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sModule\s+om_udp}) }
-        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sHost\s+logserver.example.com}) }
-        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sPort\s+6371}) }
-        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sExec\s+to_syslog_ietf\(\);}) }
-        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{</Output>}) }
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{<Output logserver>\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sModule\s+om_udp\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sHost\s+logserver.example.com\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sPort\s+6371\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sExec\s+to_syslog_ietf\(\);\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{</Output>\r\n}) }
       end
     end
 
@@ -50,10 +50,10 @@ describe 'nxlog::config::output', type: :define do
       let(:title) { 'logfile' }
 
       describe 'builds an Output section for the config file which' do
-        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{<Output logfile>}) }
-        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{\s\sModule\s+om_file}) }
-        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{\s\sFile\s+'C:/logfile\.log'}) }
-        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{</Output>}) }
+        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{<Output logfile>\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{\s\sModule\s+om_file\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{\s\sFile\s+'C:/logfile\.log'\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{</Output>\r\n}) }
       end
     end
 
@@ -78,16 +78,107 @@ describe 'nxlog::config::output', type: :define do
       let(:title) { 'sslout' }
 
       describe 'builds an Output section for the config file which' do
-        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{<Output sslout>}) }
-        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sModule\s+om_ssl}) }
-        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sHost\s+logserver.example.com}) }
-        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sOutputType Binary}) }
-        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sCAFile %CERTDIR%/ca.pem}) }
-        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sCertFile %CERTDIR%/client-cert.pem}) }
-        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sCertKeyFile %CERTDIR%/client-key.pem}) }
-        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sKeyPass secret}) }
-        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sAllowUntrusted TRUE}) }
-        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{</Output>}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{<Output sslout>\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sModule\s+om_ssl\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sHost\s+logserver.example.com\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sOutputType Binary\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sCAFile %CERTDIR%/ca.pem\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sCertFile %CERTDIR%/client-cert.pem\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sCertKeyFile %CERTDIR%/client-key.pem\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sKeyPass secret\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sAllowUntrusted TRUE\r\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{</Output>\r\n}) }
+      end
+    end
+  end
+
+  context 'On Linux' do
+    let :facts do
+      {
+        kernel: 'Linux',
+        osfamily: 'RedHat',
+        operatingsystem: 'RedHat',
+        concat_basedir: File.join(Puppet[:vardir], 'concat'),
+      }
+    end
+
+    describe 'outputting to a remote host' do
+      let :pre_condition do
+        "class {'nxlog':
+          conf_dir         => '/etc',
+          conf_file        => 'nxlog.conf',
+          nxlog_root       => '/etc',
+          output_address   => 'logserver.example.com',
+          output_execs     => [ 'to_syslog_ietf()', ],
+          output_module    => 'om_udp',
+          output_port      => '6371',
+        }"
+      end
+
+      let(:title) { 'logserver' }
+
+      describe 'builds an Output section for the config file which' do
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{<Output logserver>\n}) }
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sModule\s+om_udp\n}) }
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sHost\s+logserver.example.com\n}) }
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sPort\s+6371\n}) }
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{\s\sExec\s+to_syslog_ietf\(\);\n}) }
+        it { is_expected.to contain_concat__fragment('output_logserver').with_content(%r{</Output>\n}) }
+      end
+    end
+
+    describe 'outputting to a local file' do
+      let :pre_condition do
+        "class {'nxlog':
+          conf_dir         => '/etc',
+          conf_file        => 'nxlog.conf',
+          nxlog_root       => '/etc',
+          output_file_path => '/etc/logfile.log',
+          output_module    => 'om_file',
+        }"
+      end
+
+      let(:title) { 'logfile' }
+
+      describe 'builds an Output section for the config file which' do
+        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{<Output logfile>\n}) }
+        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{\s\sModule\s+om_file\n}) }
+        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{\s\sFile\s+'/etc/logfile\.log'\n}) }
+        it { is_expected.to contain_concat__fragment('output_logfile').with_content(%r{</Output>\n}) }
+      end
+    end
+
+    describe 'sending binary data with module om_ssl' do
+      let :pre_condition do
+        "class {'nxlog':
+          nxlog_root       => '/etc',
+          conf_dir         => '/etc',
+          output_address   => 'logserver.example.com',
+          output_module    => 'om_ssl',
+          output_options   => [
+            'OutputType Binary',
+            'CAFile %CERTDIR%/ca.pem',
+            'CertFile %CERTDIR%/client-cert.pem',
+            'CertKeyFile %CERTDIR%/client-key.pem',
+            'KeyPass secret',
+            'AllowUntrusted TRUE'
+          ],
+        }"
+      end
+
+      let(:title) { 'sslout' }
+
+      describe 'builds an Output section for the config file which' do
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{<Output sslout>\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sModule\s+om_ssl\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sHost\s+logserver.example.com\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sOutputType Binary\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sCAFile %CERTDIR%/ca.pem\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sCertFile %CERTDIR%/client-cert.pem\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sCertKeyFile %CERTDIR%/client-key.pem\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sKeyPass secret\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{\s\sAllowUntrusted TRUE\n}) }
+        it { is_expected.to contain_concat__fragment('output_sslout').with_content(%r{</Output>\n}) }
       end
     end
   end

--- a/spec/defines/config_processor_spec.rb
+++ b/spec/defines/config_processor_spec.rb
@@ -35,12 +35,12 @@ describe 'nxlog::config::processor', type: :define do
 
       # rubocop:disable Metrics/LineLength
       describe 'builds a Processor section for the config file which' do
-        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{<Processor transformer>}) }
-        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sModule\s+pm_transformer}) }
-        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sInputFormat\s+syslog_rfc3164}) }
-        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sOutputFormat\s+csv}) }
-        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sCSVOutputFields\s+\$facility,\s\$severity,\s\$timestamp,\s\$hostname,\s\$application,\s\$pid,\s\$message}) }
-        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{</Processor>}) }
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{<Processor transformer>\r\n}) }
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sModule\s+pm_transformer\r\n}) }
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sInputFormat\s+syslog_rfc3164\r\n}) }
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sOutputFormat\s+csv\r\n}) }
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sCSVOutputFields\s+\$facility,\s\$severity,\s\$timestamp,\s\$hostname,\s\$application,\s\$pid,\s\$message\r\n}) }
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{</Processor>\r\n}) }
       end
       # rubocop:enable Metrics/LineLength
     end
@@ -49,6 +49,69 @@ describe 'nxlog::config::processor', type: :define do
       let :pre_condition do
         "class {'nxlog':
           conf_dir         => 'C:/nxlog/conf',
+          conf_file        => 'nxlog.conf',
+          processor_module => 'foo',
+        }"
+      end
+
+      let(:title) { 'foo' }
+
+      it do
+        expect {
+          is_expected.to compile
+        }.to raise_error(%r{A template for foo has not been created yet.})
+      end
+    end
+  end
+
+  context 'On Linux' do
+    let :facts do
+      {
+        kernel: 'Linux',
+        osfamily: 'RedHat',
+        operatingsystem: 'RedHat',
+        concat_basedir: File.join(Puppet[:vardir], 'concat'),
+      }
+    end
+
+    context 'with pm_transformer' do
+      let :pre_condition do
+        "class {'nxlog':
+          conf_dir                    => '/etc',
+          conf_file                   => 'nxlog.conf',
+          processor_module            => 'pm_transformer',
+          processor_input_format      => 'syslog_rfc3164',
+          processor_output_format     => 'csv',
+          processor_csv_output_fields => [
+            '$facility',
+            '$severity',
+            '$timestamp',
+            '$hostname',
+            '$application',
+            '$pid',
+            '$message',
+          ],
+        }"
+      end
+
+      let(:title) { 'transformer' }
+
+      # rubocop:disable Metrics/LineLength
+      describe 'builds a Processor section for the config file which' do
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{<Processor transformer>\n}) }
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sModule\s+pm_transformer\n}) }
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sInputFormat\s+syslog_rfc3164\n}) }
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sOutputFormat\s+csv\n}) }
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{\s\sCSVOutputFields\s+\$facility,\s\$severity,\s\$timestamp,\s\$hostname,\s\$application,\s\$pid,\s\$message\n}) }
+        it { is_expected.to contain_concat__fragment('processor_transformer').with_content(%r{</Processor>\n}) }
+      end
+      # rubocop:enable Metrics/LineLength
+    end
+
+    context 'with an unknown processor module' do
+      let :pre_condition do
+        "class {'nxlog':
+          conf_dir         => '/etc',
           conf_file        => 'nxlog.conf',
           processor_module => 'foo',
         }"

--- a/spec/defines/config_processor_spec.rb
+++ b/spec/defines/config_processor_spec.rb
@@ -56,11 +56,7 @@ describe 'nxlog::config::processor', type: :define do
 
       let(:title) { 'foo' }
 
-      it do
-        expect {
-          is_expected.to compile
-        }.to raise_error(%r{A template for foo has not been created yet.})
-      end
+      it { is_expected.to compile.and_raise_error(%r{A template for foo has not been created yet.}) }
     end
   end
 
@@ -119,11 +115,7 @@ describe 'nxlog::config::processor', type: :define do
 
       let(:title) { 'foo' }
 
-      it do
-        expect {
-          is_expected.to compile
-        }.to raise_error(%r{A template for foo has not been created yet.})
-      end
+      it { is_expected.to compile.and_raise_error(%r{A template for foo has not been created yet.}) }
     end
   end
 end

--- a/spec/defines/config_route_spec.rb
+++ b/spec/defines/config_route_spec.rb
@@ -25,9 +25,9 @@ describe 'nxlog::config::route', type: :define do
       let(:title) { 'remote' }
 
       describe 'builds Route section for the config file which' do
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>}) }
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json\s=>\slogserver}) }
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>\r\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json\s=>\slogserver\r\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>\r\n}) }
       end
     end
 
@@ -45,9 +45,9 @@ describe 'nxlog::config::route', type: :define do
       let(:title) { 'remote' }
 
       describe 'builds Route section for the config file which' do
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>}) }
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json\s=>\slogserver,local_file}) }
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>\r\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json\s=>\slogserver,local_file\r\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>\r\n}) }
       end
     end
 
@@ -65,9 +65,9 @@ describe 'nxlog::config::route', type: :define do
       let(:title) { 'remote' }
 
       describe 'builds Route section for the config file which' do
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>}) }
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json,app_log\s=>\slogserver}) }
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>\r\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json,app_log\s=>\slogserver\r\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>\r\n}) }
       end
     end
 
@@ -85,9 +85,100 @@ describe 'nxlog::config::route', type: :define do
       let(:title) { 'remote' }
 
       describe 'builds a Route section for the config file which' do
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>}) }
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json,app_log\s=>\slogserver,local_file}) }
-        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>\r\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json,app_log\s=>\slogserver,local_file\r\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>\r\n}) }
+      end
+    end
+  end
+
+  context 'On Linux' do
+    let :facts do
+      {
+        kernel: 'Linux',
+        osfamily: 'Redhat',
+        operatingsystem: 'RedHat',
+        concat_basedir: File.join(Puppet[:vardir], 'concat'),
+      }
+    end
+
+    describe 'routing a single source to a single destination' do
+      let :pre_condition do
+        "class {'nxlog':
+          conf_dir          => '/etc',
+          conf_file         => 'nxlog.conf',
+          nxlog_root        => '/etc',
+          route_destination => [ 'logserver', ],
+          route_source      => [ 'eventlog_json', ],
+        }"
+      end
+
+      let(:title) { 'remote' }
+
+      describe 'builds Route section for the config file which' do
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json\s=>\slogserver\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>\n}) }
+      end
+    end
+
+    describe 'routing a single source to two destinations' do
+      let :pre_condition do
+        "class {'nxlog':
+          conf_dir          => '/etc',
+          conf_file         => 'nxlog.conf',
+          nxlog_root        => '/etc',
+          route_destination => [ 'logserver', 'local_file' ],
+          route_source      => [ 'eventlog_json', ],
+        }"
+      end
+
+      let(:title) { 'remote' }
+
+      describe 'builds Route section for the config file which' do
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json\s=>\slogserver,local_file\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>\n}) }
+      end
+    end
+
+    describe 'routing a two sources to a single destination' do
+      let :pre_condition do
+        "class {'nxlog':
+          conf_dir          => '/etc',
+          conf_file         => 'nxlog.conf',
+          nxlog_root        => '/etc',
+          route_destination => [ 'logserver', ],
+          route_source      => [ 'eventlog_json', 'app_log', ],
+        }"
+      end
+
+      let(:title) { 'remote' }
+
+      describe 'builds Route section for the config file which' do
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json,app_log\s=>\slogserver\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>\n}) }
+      end
+    end
+
+    describe 'routing two sources to two destinations' do
+      let :pre_condition do
+        "class {'nxlog':
+          conf_dir          => '/etc',
+          conf_file         => 'nxlog.conf',
+          nxlog_root        => '/etc',
+          route_destination => [ 'logserver', 'local_file' ],
+          route_source      => [ 'eventlog_json', 'app_log', ],
+        }"
+      end
+
+      let(:title) { 'remote' }
+
+      describe 'builds a Route section for the config file which' do
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{<Route remote>\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{\s\sPath\s+eventlog_json,app_log\s=>\slogserver,local_file\n}) }
+        it { is_expected.to contain_concat__fragment('route_remote').with_content(%r{</Route>\n}) }
       end
     end
   end


### PR DESCRIPTION
This addresses a change in the last release that always converted templates to windows line ending, but will now convert to correct line ending based on kernel fact (including appropriate tests).

What do you think?